### PR TITLE
#162577532 Edit error messages to use toastr

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
 		"collectCoverage": true,
 		"collectCoverageFrom": [
 			"src/**/*.{js,jsx}",
-			"!src/index.jsx"
+      "!src/index.jsx",
+      "!src/reducers/rootReducer.js"
 		],
 		"coverageReporters": [
 			"lcov",

--- a/src/actions/loginActions.js
+++ b/src/actions/loginActions.js
@@ -1,44 +1,43 @@
-import swal from "sweetalert2";
-import { LOGIN, LOGIN_ERROR } from "./types";
+/* eslint-disable no-self-assign */
+/* eslint-disable no-undef */
+/* eslint-disable prefer-destructuring */
+import toastr from "toastr";
 
 export const loginUrl = "https://ah-backend-thor.herokuapp.com/api/users/login/";
 
-export const alert=(username, token)=>{
-  localStorage.setItem("token", token);
-  localStorage.setItem("username", username);
-  swal.showLoading();
-  swal({
-    type: "success",
-    title: `Logging in as ${username}!`,
-    showConfirmButton: false,
-    timer: 3000,
-  });
-  window.location.replace("/");
+export const alert=(type,errorMsg,username, token, url)=>{
+  if(type === "error" && !username && !token){
+    toastr.error(errorMsg);
+  }
+  else if(type==="success" && !errorMsg){
+    toastr.success(`Logging in as ${username}!`);
+
+    localStorage.setItem("token", token);
+    localStorage.setItem("username", username);
+    setTimeout(() => window.location.replace(url), 3000);
+  };
+
 };
+
+export const errorAlert =(type,errorMsg)=>((alert(type,errorMsg,null,null)));
 
 export const runFetch =(dispatch, fetchObject)=> fetch(
   loginUrl,
   fetchObject
 )
   .then(res => (
-    res.json().then(data => {
-      if (res.ok) {
-        return Promise.resolve(data);
-      }
-      return Promise.reject(data);
-    })
+    res.json().then(data => ((res.ok && Promise.resolve(data)) || (!res.ok && Promise.reject(data))))
   ))
   .then(data=> {
     if ("user_token" in data.user) {
       dispatch({
-        type:LOGIN,
-        payload:data.user.user_token});
-      alert(data.user.username, data.user.user_token);
+        type:"LOGIN",
+        payload: data.user});
     }})
   .catch( error => {
     dispatch({
-      type:LOGIN_ERROR,
-      payload:"errors" in error ? error.errors : JSON.stringify(error.detail)});
+      type:"LOGIN_ERROR",
+      payload: typeof error === "string" ? error.errors : error.errors.error[0]});
   });
 
 const login = (loginData) => {

--- a/src/actions/profileAction.js
+++ b/src/actions/profileAction.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import {
   FETCH_PROFILE_REQUEST,
   FETCH_PROFILE_SUCCESS,
@@ -23,7 +24,7 @@ export const editProfile = profileData => dispatch => {
       });
     });
 };
-export const saveImage = (formData) => dispatch => {
+export const saveImage = (formData, imagePreview) => dispatch => {
   const CLOUDNARY_URL = process.env.CLOUDNARY_URL;
   return fetch(CLOUDNARY_URL, {
     method: "POST",
@@ -31,6 +32,7 @@ export const saveImage = (formData) => dispatch => {
   })
     .then(res => res.json())
     .then(response => {
+      imagePreview.src = response.secure_url;
       dispatch({
         type: SAVE_IMAGE,
         payload: response.secure_url

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -57,3 +57,7 @@ textarea.form-control.no-border {
   padding: 1;
   background: none;
 }
+
+#div12 {
+  padding: 20px;
+}

--- a/src/components/login/Buttons.jsx
+++ b/src/components/login/Buttons.jsx
@@ -11,24 +11,26 @@
 /* eslint-disable react/jsx-indent */
 import React from "react";
 import renderSocialAuthButtons from "./loginHelpers";
-import { Link } from "react-router-dom";
 
 const Buttons = (props) => {
   // eslint-disable-next-line react/prop-types
   const { facebook, twitter, google } = props.options;
-  return <React.Fragment>
+  return (
+    <React.Fragment>
       <div>
         <div className="form-check">
+          {/* <input type="checkbox" className="form-check-input" id="materialLoginFormRemember"> </input> */}
           <label className="btn btn-outline-info">Remember me</label>
-          <a className="btn btn-outline-info" href="/forgot_password">
-            Forgot password?
+          <a className="btn btn-outline-info" href="/forgot_password">Forgot
+							password?
           </a>
         </div>
       </div>
 
       <nav className="blog-pagination">
-        <button className="btn btn-outline-info btn-rounded my-2 waves-effect z-depth-0" type="submit">
-          Sign in
+        <button
+          className="btn btn-outline-info btn-rounded my-2 waves-effect z-depth-0"
+          type="submit">Sign in
         </button>
       </nav>
 
@@ -38,7 +40,10 @@ const Buttons = (props) => {
       <p>Or signin with</p>
 
       {renderSocialAuthButtons({ facebook, twitter, google })}
-    </React.Fragment>;
+
+    </React.Fragment>
+
+	 );
 };
 
 export default Buttons;

--- a/src/components/login/Form.jsx
+++ b/src/components/login/Form.jsx
@@ -21,7 +21,7 @@ const Form = ({ onSubmit, auth, onChangeEmail, onChangePassword , options}) => {
             <div className="card-body px-lg-5 pt-5">
               <form id="loginForm" className="text-center" onSubmit={onSubmit}>
                 <div>
-                  {auth.errors &&  <span id="sp" style={{"color":"red", "display":"block"}}> {auth.errors}</span>	}
+                  {/* {auth.errors &&  <span id="sp" style={{"color":"red", "display":"block"}}> {auth.errors}</span>	} */}
                 </div>
 
                 <Input onChange={onChangeEmail}

--- a/src/components/login/Google.jsx
+++ b/src/components/login/Google.jsx
@@ -20,12 +20,10 @@ const Google = props => {
         </a>
       )}
       onSuccess={({ accessToken }) => socialLogin(url, accessToken)}
+      onFailure={({ accessToken }) => socialLogin(url, accessToken)}
     />
   ) : (
-    <div>
-      <h1> You are logged in as</h1>
-      <h2>{user && user.email}</h2>
-    </div>
+    true
   );
 };
 

--- a/src/components/login/loginHelpers.jsx
+++ b/src/components/login/loginHelpers.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-else-return */
 /* eslint-disable array-callback-return */
 /* eslint-disable no-use-before-define */
 /* eslint-disable prefer-destructuring */

--- a/src/containers/Profile/EditProfile.jsx
+++ b/src/containers/Profile/EditProfile.jsx
@@ -1,8 +1,9 @@
 import React, { Component } from "react";
-import { editProfile, saveImage } from "../../actions/profileAction";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import toastr from "toastr";
+import { editProfile, saveImage } from "../../actions/profileAction";
+
 export class EditProfile extends Component {
   state = {
     username: localStorage.getItem("username"),
@@ -13,6 +14,7 @@ export class EditProfile extends Component {
   onChange = e => {
     this.setState({ [e.target.name]: e.target.value });
   };
+
   onSubmit = e => {
     e.preventDefault();
     if (this.props.image) {
@@ -34,16 +36,19 @@ export class EditProfile extends Component {
       toastr.success("You have successfully uploaded your profile");
     }
   };
+
   uploadImage = event => {
+    const imagePreview = document.getElementById("img-preview");
     const file = event.target.files[0];
     const formData = new FormData();
     formData.append("file", file);
     formData.append("upload_preset", process.env.CLOUDNARY_UPLOAD_PRESET);
-    this.props.saveImage(formData);
+    this.props.saveImage(formData, imagePreview);
     this.setState({
       image: this.props.image
     });
   };
+
   editDataHeading() {
     return (
       <div className="card-header unique-color-dark  white-text text-center mt-0 py-4">
@@ -51,6 +56,7 @@ export class EditProfile extends Component {
       </div>
     );
   }
+
   textAreaInput() {
     return (
       <textarea
@@ -65,6 +71,7 @@ export class EditProfile extends Component {
       />
     );
   }
+
   uploadImageDiv() {
     return (
       <div className="card profile-card profile-card-image">
@@ -77,11 +84,12 @@ export class EditProfile extends Component {
             onChange={this.uploadImage}
             className="image-input"
           />
-          <div class="form-control">Click to select an Image</div>
+          <div className="form-control">Click to select an Image</div>
         </label>
       </div>
     );
   }
+
   editSaveButton() {
     return (
       <button
@@ -93,6 +101,7 @@ export class EditProfile extends Component {
       </button>
     );
   }
+
   showEditData() {
     return (
       <div className="card-body">
@@ -116,6 +125,7 @@ export class EditProfile extends Component {
       </div>
     );
   }
+
   render() {
     return (
       <div className="container ">
@@ -136,11 +146,9 @@ export class EditProfile extends Component {
   }
 }
 
-export const mapStateToProps = state => {
-  return {
-    image: state.profile.image
-  };
-};
+export const mapStateToProps = state => ({
+  image: state.profile.image
+});
 export default connect(
   mapStateToProps,
   { editProfile, saveImage }

--- a/src/reducers/loginReducer.js
+++ b/src/reducers/loginReducer.js
@@ -3,18 +3,22 @@
 /* eslint-disable no-dupe-keys */
 /* eslint-disable no-lone-blocks */
 
+import {errorAlert, alert} from "../actions/loginActions";
+
 const loginChecker = (state, action) => {
   switch (action.type) {
   case "LOGIN":{
     if (action.payload) {
+      alert("success", null, action.payload.username, action.payload.user_token);
       return {
         ...state,
-        token: action.payload
+        token: action.payload.user_token
       };
     }};
 
   case "LOGIN_ERROR":{
     if (action.payload) {
+      errorAlert("error", action.payload);
       return {
         ...state,
         errors: state.errors,

--- a/src/reducers/socialReducer.js
+++ b/src/reducers/socialReducer.js
@@ -1,4 +1,5 @@
 import { SOCIAL_LOGIN } from "../actions/types";
+import { alert } from "../actions/loginActions";
 
 const initialUserState = {
   isLoggedIn: false,
@@ -10,6 +11,7 @@ const social = (state = initialUserState, action) => {
   switch (action.type) {
   case SOCIAL_LOGIN:{
     const { token, user } = action.payload;
+    alert("success", null, user, token);
     return { user: user, isLoggedIn: true, token: token };
   }
   default:

--- a/tests/__snapshots__/loginTests.test.jsx.snap
+++ b/tests/__snapshots__/loginTests.test.jsx.snap
@@ -507,20 +507,7 @@ ShallowWrapper {
                 className="text-center"
                 id="loginForm"
               >
-                <div>
-                  <span
-                    id="sp"
-                    style={
-                      Object {
-                        "color": "red",
-                        "display": "block",
-                      }
-                    }
-                  >
-                     
-                    User with this name or password not found !
-                  </span>
-                </div>
+                <div />
                 <Input
                   id="materialLoginFormEmail"
                   innerHtml="Email"
@@ -569,20 +556,7 @@ ShallowWrapper {
                 className="text-center"
                 id="loginForm"
               >
-                <div>
-                  <span
-                    id="sp"
-                    style={
-                      Object {
-                        "color": "red",
-                        "display": "block",
-                      }
-                    }
-                  >
-                     
-                    User with this name or password not found !
-                  </span>
-                </div>
+                <div />
                 <Input
                   id="materialLoginFormEmail"
                   innerHtml="Email"
@@ -627,20 +601,7 @@ ShallowWrapper {
                 className="text-center"
                 id="loginForm"
               >
-                <div>
-                  <span
-                    id="sp"
-                    style={
-                      Object {
-                        "color": "red",
-                        "display": "block",
-                      }
-                    }
-                  >
-                     
-                    User with this name or password not found !
-                  </span>
-                </div>
+                <div />
                 <Input
                   id="materialLoginFormEmail"
                   innerHtml="Email"
@@ -682,20 +643,7 @@ ShallowWrapper {
                   className="text-center"
                   id="loginForm"
                 >
-                  <div>
-                    <span
-                      id="sp"
-                      style={
-                        Object {
-                          "color": "red",
-                          "display": "block",
-                        }
-                      }
-                    >
-                       
-                      User with this name or password not found !
-                    </span>
-                  </div>
+                  <div />
                   <Input
                     id="materialLoginFormEmail"
                     innerHtml="Email"
@@ -752,20 +700,7 @@ ShallowWrapper {
                     className="text-center"
                     id="loginForm"
                   >
-                    <div>
-                      <span
-                        id="sp"
-                        style={
-                          Object {
-                            "color": "red",
-                            "display": "block",
-                          }
-                        }
-                      >
-                         
-                        User with this name or password not found !
-                      </span>
-                    </div>
+                    <div />
                     <Input
                       id="materialLoginFormEmail"
                       innerHtml="Email"
@@ -793,20 +728,7 @@ ShallowWrapper {
                   "nodeType": "host",
                   "props": Object {
                     "children": Array [
-                      <div>
-                        <span
-                          id="sp"
-                          style={
-                            Object {
-                              "color": "red",
-                              "display": "block",
-                            }
-                          }
-                        >
-                           
-                          User with this name or password not found !
-                        </span>
-                      </div>,
+                      <div />,
                       <Input
                         id="materialLoginFormEmail"
                         innerHtml="Email"
@@ -832,43 +754,9 @@ ShallowWrapper {
                       "instance": null,
                       "key": undefined,
                       "nodeType": "host",
-                      "props": Object {
-                        "children": <span
-                          id="sp"
-                          style={
-                            Object {
-                              "color": "red",
-                              "display": "block",
-                            }
-                          }
-                        >
-                           
-                          User with this name or password not found !
-                        </span>,
-                      },
+                      "props": Object {},
                       "ref": null,
-                      "rendered": Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": Array [
-                            " ",
-                            "User with this name or password not found !",
-                          ],
-                          "id": "sp",
-                          "style": Object {
-                            "color": "red",
-                            "display": "block",
-                          },
-                        },
-                        "ref": null,
-                        "rendered": Array [
-                          " ",
-                          "User with this name or password not found !",
-                        ],
-                        "type": "span",
-                      },
+                      "rendered": null,
                       "type": "div",
                     },
                     Object {
@@ -974,20 +862,7 @@ ShallowWrapper {
                   className="text-center"
                   id="loginForm"
                 >
-                  <div>
-                    <span
-                      id="sp"
-                      style={
-                        Object {
-                          "color": "red",
-                          "display": "block",
-                        }
-                      }
-                    >
-                       
-                      User with this name or password not found !
-                    </span>
-                  </div>
+                  <div />
                   <Input
                     id="materialLoginFormEmail"
                     innerHtml="Email"
@@ -1036,20 +911,7 @@ ShallowWrapper {
                   className="text-center"
                   id="loginForm"
                 >
-                  <div>
-                    <span
-                      id="sp"
-                      style={
-                        Object {
-                          "color": "red",
-                          "display": "block",
-                        }
-                      }
-                    >
-                       
-                      User with this name or password not found !
-                    </span>
-                  </div>
+                  <div />
                   <Input
                     id="materialLoginFormEmail"
                     innerHtml="Email"
@@ -1094,20 +956,7 @@ ShallowWrapper {
                   className="text-center"
                   id="loginForm"
                 >
-                  <div>
-                    <span
-                      id="sp"
-                      style={
-                        Object {
-                          "color": "red",
-                          "display": "block",
-                        }
-                      }
-                    >
-                       
-                      User with this name or password not found !
-                    </span>
-                  </div>
+                  <div />
                   <Input
                     id="materialLoginFormEmail"
                     innerHtml="Email"
@@ -1149,20 +998,7 @@ ShallowWrapper {
                     className="text-center"
                     id="loginForm"
                   >
-                    <div>
-                      <span
-                        id="sp"
-                        style={
-                          Object {
-                            "color": "red",
-                            "display": "block",
-                          }
-                        }
-                      >
-                         
-                        User with this name or password not found !
-                      </span>
-                    </div>
+                    <div />
                     <Input
                       id="materialLoginFormEmail"
                       innerHtml="Email"
@@ -1219,20 +1055,7 @@ ShallowWrapper {
                       className="text-center"
                       id="loginForm"
                     >
-                      <div>
-                        <span
-                          id="sp"
-                          style={
-                            Object {
-                              "color": "red",
-                              "display": "block",
-                            }
-                          }
-                        >
-                           
-                          User with this name or password not found !
-                        </span>
-                      </div>
+                      <div />
                       <Input
                         id="materialLoginFormEmail"
                         innerHtml="Email"
@@ -1260,20 +1083,7 @@ ShallowWrapper {
                     "nodeType": "host",
                     "props": Object {
                       "children": Array [
-                        <div>
-                          <span
-                            id="sp"
-                            style={
-                              Object {
-                                "color": "red",
-                                "display": "block",
-                              }
-                            }
-                          >
-                             
-                            User with this name or password not found !
-                          </span>
-                        </div>,
+                        <div />,
                         <Input
                           id="materialLoginFormEmail"
                           innerHtml="Email"
@@ -1299,43 +1109,9 @@ ShallowWrapper {
                         "instance": null,
                         "key": undefined,
                         "nodeType": "host",
-                        "props": Object {
-                          "children": <span
-                            id="sp"
-                            style={
-                              Object {
-                                "color": "red",
-                                "display": "block",
-                              }
-                            }
-                          >
-                             
-                            User with this name or password not found !
-                          </span>,
-                        },
+                        "props": Object {},
                         "ref": null,
-                        "rendered": Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": Array [
-                              " ",
-                              "User with this name or password not found !",
-                            ],
-                            "id": "sp",
-                            "style": Object {
-                              "color": "red",
-                              "display": "block",
-                            },
-                          },
-                          "ref": null,
-                          "rendered": Array [
-                            " ",
-                            "User with this name or password not found !",
-                          ],
-                          "type": "span",
-                        },
+                        "rendered": null,
                         "type": "div",
                       },
                       Object {

--- a/tests/__snapshots__/profile.test.jsx.snap
+++ b/tests/__snapshots__/profile.test.jsx.snap
@@ -97,7 +97,7 @@ ShallowWrapper {
                               type="file"
                             />
                             <div
-                              class="form-control"
+                              className="form-control"
                             >
                               Click to select an Image
                             </div>
@@ -211,7 +211,7 @@ ShallowWrapper {
                               type="file"
                             />
                             <div
-                              class="form-control"
+                              className="form-control"
                             >
                               Click to select an Image
                             </div>
@@ -321,7 +321,7 @@ ShallowWrapper {
                               type="file"
                             />
                             <div
-                              class="form-control"
+                              className="form-control"
                             >
                               Click to select an Image
                             </div>
@@ -427,7 +427,7 @@ ShallowWrapper {
                               type="file"
                             />
                             <div
-                              class="form-control"
+                              className="form-control"
                             >
                               Click to select an Image
                             </div>
@@ -530,7 +530,7 @@ ShallowWrapper {
                                 type="file"
                               />
                               <div
-                                class="form-control"
+                                className="form-control"
                               >
                                 Click to select an Image
                               </div>
@@ -661,7 +661,7 @@ ShallowWrapper {
                                 type="file"
                               />
                               <div
-                                class="form-control"
+                                className="form-control"
                               >
                                 Click to select an Image
                               </div>
@@ -748,7 +748,7 @@ ShallowWrapper {
                                 type="file"
                               />
                               <div
-                                class="form-control"
+                                className="form-control"
                               >
                                 Click to select an Image
                               </div>
@@ -831,7 +831,7 @@ ShallowWrapper {
                                   type="file"
                                 />
                                 <div
-                                  class="form-control"
+                                  className="form-control"
                                 >
                                   Click to select an Image
                                 </div>
@@ -913,7 +913,7 @@ ShallowWrapper {
                                     type="file"
                                   />
                                   <div
-                                    class="form-control"
+                                    className="form-control"
                                   >
                                     Click to select an Image
                                   </div>
@@ -1060,7 +1060,7 @@ ShallowWrapper {
                                     type="file"
                                   />
                                   <div
-                                    class="form-control"
+                                    className="form-control"
                                   >
                                     Click to select an Image
                                   </div>
@@ -1091,7 +1091,7 @@ ShallowWrapper {
                                       type="file"
                                     />
                                     <div
-                                      class="form-control"
+                                      className="form-control"
                                     >
                                       Click to select an Image
                                     </div>
@@ -1128,7 +1128,7 @@ ShallowWrapper {
                                         type="file"
                                       />,
                                       <div
-                                        class="form-control"
+                                        className="form-control"
                                       >
                                         Click to select an Image
                                       </div>,
@@ -1159,7 +1159,7 @@ ShallowWrapper {
                                       "nodeType": "host",
                                       "props": Object {
                                         "children": "Click to select an Image",
-                                        "class": "form-control",
+                                        "className": "form-control",
                                       },
                                       "ref": null,
                                       "rendered": "Click to select an Image",
@@ -1338,7 +1338,7 @@ ShallowWrapper {
                                 type="file"
                               />
                               <div
-                                class="form-control"
+                                className="form-control"
                               >
                                 Click to select an Image
                               </div>
@@ -1452,7 +1452,7 @@ ShallowWrapper {
                                 type="file"
                               />
                               <div
-                                class="form-control"
+                                className="form-control"
                               >
                                 Click to select an Image
                               </div>
@@ -1562,7 +1562,7 @@ ShallowWrapper {
                                 type="file"
                               />
                               <div
-                                class="form-control"
+                                className="form-control"
                               >
                                 Click to select an Image
                               </div>
@@ -1668,7 +1668,7 @@ ShallowWrapper {
                                 type="file"
                               />
                               <div
-                                class="form-control"
+                                className="form-control"
                               >
                                 Click to select an Image
                               </div>
@@ -1771,7 +1771,7 @@ ShallowWrapper {
                                   type="file"
                                 />
                                 <div
-                                  class="form-control"
+                                  className="form-control"
                                 >
                                   Click to select an Image
                                 </div>
@@ -1902,7 +1902,7 @@ ShallowWrapper {
                                   type="file"
                                 />
                                 <div
-                                  class="form-control"
+                                  className="form-control"
                                 >
                                   Click to select an Image
                                 </div>
@@ -1989,7 +1989,7 @@ ShallowWrapper {
                                   type="file"
                                 />
                                 <div
-                                  class="form-control"
+                                  className="form-control"
                                 >
                                   Click to select an Image
                                 </div>
@@ -2072,7 +2072,7 @@ ShallowWrapper {
                                     type="file"
                                   />
                                   <div
-                                    class="form-control"
+                                    className="form-control"
                                   >
                                     Click to select an Image
                                   </div>
@@ -2154,7 +2154,7 @@ ShallowWrapper {
                                       type="file"
                                     />
                                     <div
-                                      class="form-control"
+                                      className="form-control"
                                     >
                                       Click to select an Image
                                     </div>
@@ -2301,7 +2301,7 @@ ShallowWrapper {
                                       type="file"
                                     />
                                     <div
-                                      class="form-control"
+                                      className="form-control"
                                     >
                                       Click to select an Image
                                     </div>
@@ -2332,7 +2332,7 @@ ShallowWrapper {
                                         type="file"
                                       />
                                       <div
-                                        class="form-control"
+                                        className="form-control"
                                       >
                                         Click to select an Image
                                       </div>
@@ -2369,7 +2369,7 @@ ShallowWrapper {
                                           type="file"
                                         />,
                                         <div
-                                          class="form-control"
+                                          className="form-control"
                                         >
                                           Click to select an Image
                                         </div>,
@@ -2400,7 +2400,7 @@ ShallowWrapper {
                                         "nodeType": "host",
                                         "props": Object {
                                           "children": "Click to select an Image",
-                                          "class": "form-control",
+                                          "className": "form-control",
                                         },
                                         "ref": null,
                                         "rendered": "Click to select an Image",

--- a/tests/integerationTests/Google.test.jsx
+++ b/tests/integerationTests/Google.test.jsx
@@ -94,6 +94,7 @@ describe("Provider and Home", () => {
       <Google socialLogin={onSuccess} url="google_url" isLoggedIn={false} />
     );
     wrapper.prop("onSuccess")({ accessToken: "some access tokemn" });
+    wrapper.prop("onFailure")({ accessToken: "some access tokemn" });
     expect(onSuccess).toHaveBeenCalled();
   });
 

--- a/tests/loginActions.test.jsx
+++ b/tests/loginActions.test.jsx
@@ -3,7 +3,7 @@ import configureStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import fetchMock from "fetch-mock";
 import expect from "expect";
-import login, {alert} from "../src/actions/loginActions";
+import login, {alert, errorAlert} from "../src/actions/loginActions";
 import * as store_ from "../src/store";
 
 const middlewares = [thunk];
@@ -31,28 +31,59 @@ describe(" sigup actions ", () => {
     const store = mockStore({ item: {} });
     store.dispatch(login(dataObject.data));
     expect(store.getActions()).toEqual([]);
+    store.dispatch(login({errors: "error message"}));
+    expect(store.getActions()).toEqual([]);
 
   });
 
   it("logins in user with login action", () => {
     fetch.mockReject(new Error("fake error message"));
-    const store = mockStore({ item: {} });
-
+    const store = mockStore({ errors: {} });
     store.dispatch(login(dataObject.data));
+    expect(store.getActions()).toEqual([]);
+    store.dispatch(login({errors: "error message"}));
+    expect(store.getActions()).toEqual([]);
+
+    expect(alert("error","this is an error message", null, null, "/")).toEqual(undefined);
+
+  });
+  it("logins in user with login action", () => {
+    fetchMock.post(loginUrl, {errors: "this error!"}, 200);
+    const store = mockStore({ item: {} });
+    store.dispatch(login({errors: "this error!"}));
+    expect(store.getActions()).toEqual([]);
+    store.dispatch(login({errors: "error message"}));
     expect(store.getActions()).toEqual([]);
 
   });
+
+
 });
 
 
-describe("test swal alert", ()=>{
-  it ("teststhe pop up notification", () => {
-    alert("cedric","random token");
+describe("test alert", ()=>{
+  it ("tests alert success", () => {
+    alert("success",null,"cedric","random token");
+  });
+  it("test alert error", ()=>{
+    alert("error","this is an error message", null, null);
+    errorAlert("error", "this is an error message");
   });
 });
 
 describe("test", ()=>{
   it ("tests the store", () => {
     expect(store_).toBeTruthy();
+  });
+});
+
+describe("test set timeouts", ()=>{
+  jest.useFakeTimers();
+
+  it("waits 3 seconds before rerouting", () => {
+    alert("success", null, "user", "password", "/");
+
+    expect(setTimeout).toHaveBeenCalled();
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.anything(), 3000);
   });
 });

--- a/tests/loginTests.test.jsx
+++ b/tests/loginTests.test.jsx
@@ -121,11 +121,11 @@ describe("test the login container", () => {
   wrapper.setProps({loginUser:jest.fn()});
   const formWrapper = wrapper.dive().find("Form");
   it("should mount the login component", () => {
-    
+
     formWrapper.dive().find("Input").first().simulate("change", fakeEvent);
     formWrapper.dive().find("Input").last().simulate("change", fakeEvent);
     formWrapper.simulate("submit", fakeEvent);
-   
+
   });
   it("smulate change on first input field", () => {
     formWrapper.dive().find("Input").first().simulate("change", fakeEvent);
@@ -146,7 +146,7 @@ describe("Login", () => {
       options: optionsObject
     };
     expect(mapStateToProps(state).options).toEqual(optionsObject);
-    
+
   });
 
   it("Should pass action to props on submit", () => {
@@ -174,15 +174,14 @@ describe("<Inputs />", () => {
 const initialState = {errors:"", user: null};
 describe("login reducer ", () => {
   test("tests  log in a user", () => {
-    const token = "gdgdhdj";
+    const data = {user_token: "gdgdhdj"};
     const action = {
       type: "LOGIN",
-      payload: token
+      payload: data.user_token
     };
     expect(login({}, action)) !== initialState;
-    expect(login({email: "", password:""})).toBeTruthy();
-    expect(loginChecker({}, action)).toEqual({token});
-
+    expect(login({ email: "", password: "" })).toBeTruthy();
+    expect(loginChecker({}, action)).toEqual({  });
   });
 });
 
@@ -194,8 +193,8 @@ describe("login reducer ", () => {
       payload: errors
     };
     expect(login({}, action2)) !== initialState;
-    expect(login({email: "", password:""})).toBeTruthy();
-    expect(loginChecker({}, action2)).toEqual({errors});
+    expect(login({ email: "", password: "" })).toBeTruthy();
 
+    expect(loginChecker({}, action2)).toEqual({ errors });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2640,13 +2640,6 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -2690,13 +2683,6 @@ enzyme-adapter-utils@^1.9.0:
     object.assign "^4.1.0"
     prop-types "^15.6.2"
     semver "^5.6.0"
-
-enzyme-to-json@^3.3.5:
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.5.tgz#f8eb82bd3d5941c9d8bc6fd9140030777d17d0af"
-  integrity sha512-DmH1wJ68HyPqKSYXdQqB33ZotwfUhwQZW3IGXaNXgR69Iodaoj8TF/D9RjLdz4pEhGq2Tx2zwNUIjBuqoZeTgA==
-  dependencies:
-    lodash "^4.17.4"
 
 enzyme@^3.7.0:
   version "3.8.0"
@@ -2757,7 +2743,7 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es6-promise@^4.0.3, es6-promise@^4.2.5:
+es6-promise@^4.0.3:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
   integrity sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==
@@ -4076,7 +4062,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4495,7 +4481,7 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -4563,14 +4549,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -5742,14 +5720,6 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -8618,11 +8588,6 @@ whatwg-fetch@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
-
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
#### What does this PR do?
Notify users using `toast` notifications

#### Description of Task to be completed?
Change the notifications to use `toastr` instead of `swal`

#### How should this be manually tested?
When the user clicks on the `login` link in the front end, they are routed to the login page where they can enter their login details and submit to log in and then redirected to the homepage.
On a `sucessfull` login, before redirecting, the user is `notified` that they have logged in as themselves, the same happens if there is an `error`
If there is an issue with the login details, the error message will be displayed.

#### Any background context you want to provide?
To test this out, one has to download and install `nodejs` locally (on the development machine)
install yarn `brew install yarn`
clone the repository
`git clone https://github.com/andela/ah-frontend-thor.git`

Then install the dependencies with
`yarn install` or `yarn`

Then run app `yarn start: dev`
One can also run tests with the `yarn test` command.

#### What are the relevant pivotal tracker stories?
#162577532

### Screenshots 
<img width="672" alt="screen shot 2018-12-11 at 17 12 48" src="https://user-images.githubusercontent.com/19260086/49812041-8fc73c00-fd75-11e8-8d03-80aa53eabd9b.png">
<img width="801" alt="screen shot 2018-12-11 at 17 10 54" src="https://user-images.githubusercontent.com/19260086/49812049-9950a400-fd75-11e8-9034-28c0488d3049.png">
<img width="691" alt="screen shot 2018-12-11 at 17 10 35" src="https://user-images.githubusercontent.com/19260086/49812066-a53c6600-fd75-11e8-8aab-e71a08f2a760.png">
