### PR TITLE
#162581213: Add descriptive colors to error messages

### DIFF
--- a/src/actions/resetPasswordAction.jsx
+++ b/src/actions/resetPasswordAction.jsx
@@ -1,4 +1,26 @@
 import toastr from "toastr";
+
+export const updateError = message => {
+  if (message == "Password updated") {
+    toastr.success(message);
+    setTimeout(() => window.location.replace("/signup"), 3000);
+  } else if (message == "Token Expired. Update failed") {
+    toastr.error(message);
+    setTimeout(() => window.location.replace("/signup"), 3000);
+  } else {
+    toastr.error(message);
+  }
+  localStorage.removeItem("reset_token");
+};
+
+export const linkError = message => {
+  if (message == "Check your email for the password reset link") {
+    toastr.success(message);
+  } else {
+    toastr.error(message);
+  }
+  setTimeout(() => window.location.replace("/signup"), 3000);
+};
 export const sendEmailLink = data => dispatch => {
   /*Sends a pasword reset link*/
   return fetch(
@@ -16,11 +38,11 @@ export const sendEmailLink = data => dispatch => {
     .then(value => {
       dispatch({ type: "LINK SENT", payload: value.user.message });
       localStorage.setItem("reset_token", value.user.token);
-      toastr.info(value.user.message);
-      setTimeout(() => window.location.replace("/"), 3000);
+      linkError(value.user.message);
     })
     .catch(error => {
       dispatch({ type: "JSON ERROR" });
+      toastr.error("server error");
       error;
     });
 };
@@ -40,12 +62,11 @@ export const changePassword = (token, data) => dispatch => {
       return response.json();
     })
     .then(value => {
-      dispatch({ type: "API ACCESS SUCCESSFUL" });
-      toastr.info(value.message);
-      localStorage.removeItem("reset_token");
-      setTimeout(() => window.location.replace("/"), 3000);
+      dispatch({ type: "UPDATE SUCCESSFUL" });
+      updateError(value.message);
     })
     .catch(error => {
+      toastr.error("server error");
       error;
     });
 };

--- a/tests/unitTests/ResetActions.test.jsx
+++ b/tests/unitTests/ResetActions.test.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import fetchMock from "fetch-mock";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
@@ -7,7 +6,9 @@ const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 import {
   sendEmailLink,
-  changePassword
+  changePassword,
+  linkError,
+  updateError
 } from "../../src/actions/resetPasswordAction";
 
 const data = {
@@ -67,7 +68,7 @@ describe("resetPasswordActions", () => {
       201
     );
 
-    const expectedActions = [{ type: "API ACCESS SUCCESSFUL" }];
+    const expectedActions = [{ type: "UPDATE SUCCESSFUL" }];
     const store = mockStore({});
 
     return store
@@ -85,5 +86,14 @@ describe("resetPasswordActions", () => {
 
     store.dispatch(changePassword(token, data));
     expect(store.getActions()).toEqual([]);
+  });
+
+  it("email link error messages", () => {
+    linkError("User does not exist");
+    linkError("Check your email for the password reset link");
+  });
+  it("password update error messages", () => {
+    updateError("Token Expired. Update failed");
+    updateError("Password updated");
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Add descriptive colors to error messages

#### Description of Task to be completed?
Error messages should  be red. Success messages should be green. Information messages should be blue. Warning messages should be orange.

#### How should this be manually tested?
When the user clicks on the `Forgot Password` button on the login page, they are redirected to the `Reset Email` page where they can enter their email, submit, and are sent a link to the email to change the password.

#### Any background context you want to provide?
- use toast for the notifications

#### What are the relevant pivotal tracker stories?
#162581213

### Screenshots 
<img width="1440" alt="reset_success" src="https://user-images.githubusercontent.com/9901086/49814593-fef35f00-fd7a-11e8-9d11-8d56af23ed22.png">

<img width="1440" alt="fail" src="https://user-images.githubusercontent.com/9901086/49814492-c8b5df80-fd7a-11e8-8bea-5e4a56fbc09d.png">

<img width="1440" alt="success" src="https://user-images.githubusercontent.com/9901086/49814465-bb98f080-fd7a-11e8-93a6-e8c3d5cc3491.png">

