### PR TITLE
#162612615 fix user messages returned on social login

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="X-UA-Compatible" content="ie=edge"> -->
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title></title>

--- a/src/reducers/socialReducer.js
+++ b/src/reducers/socialReducer.js
@@ -7,13 +7,20 @@ const initialUserState = {
   user: null,
   token: null
 };
+let data = {};
 
 const social = (state = initialUserState, action) => {
   switch (action.type) {
   case SOCIAL_LOGIN:{
     const { token, user } = action.payload;
-    alert("success", null, user, token, "/");
-    return { user: user, isLoggedIn: true, token: token };
+    if (token){
+      data = { user: user.username, isLoggedIn: true, token: token };
+      alert("success", null, data.user, data.token, "/");
+    }else{
+      data = { user: user.username, isLoggedIn: true, token: user.token };
+      alert("success", null, data.user, data.token, "/");
+    }
+    return data;
   }
   default:
     return state;

--- a/tests/unitTests/SocialReducer.test.jsx
+++ b/tests/unitTests/SocialReducer.test.jsx
@@ -10,16 +10,30 @@ describe("socialLoginReducer", () => {
     });
   });
 
-  it("updates state on SOCIAL_LOGIN action type", () => {
+  it("updates state on SOCIAL_LOGIN with GOOGLE action type", () => {
     expect(
       social(undefined, {
         type: SOCIAL_LOGIN,
-        payload: { token: "nkfknfldfl" }
+        payload: { token: "token", user:{username:"joshua"}}
       })
     ).toEqual({
       isLoggedIn: true,
-      user: undefined,
-      token: "nkfknfldfl"
+      token: "token",
+      user:"joshua"
     });
   });
+
+  it("updates state on SOCIAL_LOGIN with FACEBOOK action type", () => {
+    expect(
+      social(undefined, {
+        type: SOCIAL_LOGIN,
+        payload: {user:{username:"joshua"}}
+      })
+    ).toEqual({
+      isLoggedIn: true,
+      token: undefined,
+      user:"joshua"
+    });
+  });
+
 });


### PR DESCRIPTION
#### What does this PR do?
- fix user messages returned when a user logs in using social login
#### Description of Task to be completed?
- currently when a user logs in using the social login functionality the messages wich are ruturned are not user friendly. This PR addresses that issue 
#### How should this be manually tested?
- Clone the repo, Run yarn to install dependencies, run yarn start:dev, click on the facebook or google login buttons to login.
#### Any background context you want to provide?
- Users should be able to see informative user friendly messages upon login success or failure
#### What are the relevant pivotal tracker stories?
#162612615