### PR TITLE
#162601645: User should receive an  verification link after registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,11 +84,6 @@
       "!src/index.jsx",
       "!src/reducers/rootReducer.js"
     ],
-    "coverageReporters": [
-      "lcov",
-      "json",
-      "html"
-    ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tests/__mocks__/fileMock.js",
       "\\.(css|scss)$": "<rootDir>/tests/__mocks__/styleMock.js"

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -9,3 +9,5 @@ export const SOCIAL_LOGIN = "SOCIAL_LOGIN";
 export const LOGIN = "LOGIN";
 export const POST_ARTICLE = "POST_ARTICLE";
 export const IMAGE_URL = "IMAGE_URL";
+export const ARTICLE_DISLIKES = "ARTICLE_DISLIKES";
+export const ARTICLE_LIKES = "ARTICLE_LIKES";

--- a/src/actions/userVerification.js
+++ b/src/actions/userVerification.js
@@ -1,0 +1,16 @@
+const userVerified = token => dispatch =>
+  fetch(`https://ah-backend-thor.herokuapp.com/api/users/update/${token}`, {
+    method: "GET",
+    mode: "cors",
+    headers: { "Content-Type": "application/json" }
+  })
+    .then(response => response.json())
+    .then(value => {
+      dispatch({
+        type: "USER_VERIFIED",
+        payload: value
+      });
+    })
+    .catch(error => error);
+
+export default userVerified;

--- a/src/components/AppRouter.jsx
+++ b/src/components/AppRouter.jsx
@@ -17,6 +17,8 @@ import EditProfile from "../containers/Profile/EditProfile";
 import "../assets/css/styles.css";
 import SignOut from "./SignOut";
 import PostArticle from "./article/PostArticle";
+import UpdateUserInfo from "../containers/EmailVerification";
+
 
 const AppRouter = () => (
   <Provider store={store}>
@@ -34,6 +36,7 @@ const AppRouter = () => (
             <Route path="/editprofile" component={EditProfile} />
             <Route path="/signout" component={SignOut} />
             <Route path="/post_article" component={PostArticle} />
+            <Route path="/updateuser" component={UpdateUserInfo} />
           </div>
         </Root>
       </React.Fragment>

--- a/src/containers/EmailVerification.jsx
+++ b/src/containers/EmailVerification.jsx
@@ -1,0 +1,29 @@
+import React, { Component } from "react";
+import userVerified from "../actions/userVerification";
+import { connect } from "react-redux";
+
+
+export class UpdateUserInfo extends Component {
+  componentDidMount() {
+    const url = window.location.search;
+    const token = url.replace("?token=", "");
+
+    const { updateUser } = this.props;
+
+    updateUser(token);
+  }
+  render() {
+    return (
+      <div />
+    );
+  }
+}
+
+export const mapDispatchToProps = dispatch => ({
+  updateUser: token => dispatch(userVerified(token))
+});
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(UpdateUserInfo);

--- a/src/index.html
+++ b/src/index.html
@@ -9,14 +9,15 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
-	<!-- Bootstrap core CSS -->
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet">
-
+  <!-- Bootstrap core CSS -->
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet">
 	<!-- Material Design Bootstrap -->
 	<link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.5.15/css/mdb.min.css" rel="stylesheet">
 	<link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" rel="stylesheet">
-	<link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
-	
+  <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+  <link href="assets/css/styles.css" rel="stylesheet">
+
 
   <title>Authors' Haven</title>
 <body>

--- a/src/reducers/emailVerification.js
+++ b/src/reducers/emailVerification.js
@@ -1,0 +1,21 @@
+import toastr from "toastr";
+
+const userState = {
+  message: ""
+};
+
+export const userVerifiedReducer = (state = userState, action) => {
+  switch (action.type) {
+  case "USER_VERIFIED":
+    setTimeout(() => window.location.replace("/login"), 3000);
+    toastr.success("Verification is complete. Continue to login");
+    return {
+      ...state,
+      message: action.payload
+    };
+  default:
+    return state;
+  }
+};
+
+export default userVerifiedReducer;

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -6,11 +6,13 @@ import profileReducer from "./profileReducer";
 import loginReducer from "./loginReducer";
 import social from "./socialReducer";
 import articleReducer from "./articleReducer";
+import userVerifiedReducer from "./emailVerification";
 
 export default combineReducers({
   signUpReducer,
   auth: loginReducer,
   profile: profileReducer,
   social,
-  articleReducer
+  articleReducer,
+  userVerifiedReducer
 });

--- a/tests/integerationTests/EmailVerification.test.jsx
+++ b/tests/integerationTests/EmailVerification.test.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Provider } from "react-redux";
+import { shallow } from "enzyme";
+import fetchMock from "fetch-mock";
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+import {
+  UpdateUserInfo,
+  mapDispatchToProps
+} from "../../src/containers/EmailVerification";
+
+import userVerified from "../../src/actions/userVerification";
+
+describe("User verification", () => {
+  const token = 3;
+  test("tests if the component is mounted", () => {
+    const store = mockStore(1);
+    const wrapper = shallow(
+      <UpdateUserInfo store={store} updateUser={jest.fn()} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("test fetch with an empty variable", () => {
+    fetch.mockResponse(JSON.stringify({ access_token: "12345" }));
+    const store = mockStore({ message: "" });
+
+    store.dispatch(userVerified(token)).then(()=>{
+      expect(store.getActions()).toEqual([
+        { type: "USER_VERIFIED", payload: value }
+      ]);
+    });
+  });
+  it("verification fails due to system error", () => {
+    fetch.mockReject(new Error("server error"));
+    const store = mockStore();
+
+
+    store.dispatch(userVerified(token));
+    expect(store.getActions()).toEqual([]);
+  });
+  it("should mount component on redirect", () => {
+    let dispatch = jest.fn();
+    mapDispatchToProps(dispatch).updateUser();
+    expect(dispatch.mock.calls.length).toBe(1);
+  });
+});

--- a/tests/integerationTests/__snapshots__/AppRouter.test.jsx.snap
+++ b/tests/integerationTests/__snapshots__/AppRouter.test.jsx.snap
@@ -62,6 +62,10 @@ ShallowWrapper {
                 component={[Function]}
                 path="/post_article"
               />
+              <Route
+                component={[Function]}
+                path="/updateuser"
+              />
             </div>
           </Root>
         </React.Fragment>
@@ -124,6 +128,10 @@ ShallowWrapper {
                 component={[Function]}
                 path="/post_article"
               />
+              <Route
+                component={[Function]}
+                path="/updateuser"
+              />
             </div>
           </Root>
         </React.Fragment>,
@@ -177,6 +185,10 @@ ShallowWrapper {
                 component={[Function]}
                 path="/post_article"
               />
+              <Route
+                component={[Function]}
+                path="/updateuser"
+              />
             </div>
           </Root>,
         },
@@ -228,6 +240,10 @@ ShallowWrapper {
                 component={[Function]}
                 path="/post_article"
               />
+              <Route
+                component={[Function]}
+                path="/updateuser"
+              />
             </div>,
           },
           "ref": null,
@@ -277,6 +293,10 @@ ShallowWrapper {
                 <Route
                   component={[Function]}
                   path="/post_article"
+                />,
+                <Route
+                  component={[Function]}
+                  path="/updateuser"
                 />,
               ],
             },
@@ -403,6 +423,18 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "component": [Function],
+                  "path": "/updateuser",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
             ],
             "type": "div",
           },
@@ -464,6 +496,10 @@ ShallowWrapper {
                 <Route
                   component={[Function]}
                   path="/post_article"
+                />
+                <Route
+                  component={[Function]}
+                  path="/updateuser"
                 />
               </div>
             </Root>
@@ -527,6 +563,10 @@ ShallowWrapper {
                   component={[Function]}
                   path="/post_article"
                 />
+                <Route
+                  component={[Function]}
+                  path="/updateuser"
+                />
               </div>
             </Root>
           </React.Fragment>,
@@ -580,6 +620,10 @@ ShallowWrapper {
                   component={[Function]}
                   path="/post_article"
                 />
+                <Route
+                  component={[Function]}
+                  path="/updateuser"
+                />
               </div>
             </Root>,
           },
@@ -631,6 +675,10 @@ ShallowWrapper {
                   component={[Function]}
                   path="/post_article"
                 />
+                <Route
+                  component={[Function]}
+                  path="/updateuser"
+                />
               </div>,
             },
             "ref": null,
@@ -680,6 +728,10 @@ ShallowWrapper {
                   <Route
                     component={[Function]}
                     path="/post_article"
+                  />,
+                  <Route
+                    component={[Function]}
+                    path="/updateuser"
                   />,
                 ],
               },
@@ -801,6 +853,18 @@ ShallowWrapper {
                   "props": Object {
                     "component": [Function],
                     "path": "/post_article",
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "component": [Function],
+                    "path": "/updateuser",
                   },
                   "ref": null,
                   "rendered": null,

--- a/tests/integerationTests/__snapshots__/EmailVerification.test.jsx.snap
+++ b/tests/integerationTests/__snapshots__/EmailVerification.test.jsx.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`User verification tests if the component is mounted 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <UpdateUserInfo
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+    updateUser={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      }
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {},
+    "ref": null,
+    "rendered": null,
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {},
+      "ref": null,
+      "rendered": null,
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/tests/unitTests/EmailVerificationReducer.test.js
+++ b/tests/unitTests/EmailVerificationReducer.test.js
@@ -1,0 +1,16 @@
+import { userVerifiedReducer } from "../../src/reducers/emailVerification";
+
+describe("user verification reducer", () => {
+  it("should return initial state", () => {
+    expect(userVerifiedReducer(undefined, {})).toEqual({ message: "" });
+  });
+
+  it("receive successful verification message", () => {
+    expect(
+      userVerifiedReducer([], {
+        type: "USER_VERIFIED",
+        payload: "Verification is complete"
+      })
+    ).toEqual({ message: "Verification is complete" });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Provide a user interface to enable the user reset his/her password

#### Description of Task to be completed?
Users should be able to presented with a reset password link

#### How should this be manually tested?
 - Clone the repository.
 - Install application dependencies using`yarn`
 - start the server using `yarn start:dev`
 - Enter `localhost:8080/signup` in the browser
 - Once successful, an email is sent to the user email account
 - Click the link in the email
 - The user will receive a successful verification message to continue and his redirected to login into his/her account

#### Any background context you want to provide?
The link in the backend should redirect the user to the user interface in the frontend

#### What are the relevant pivotal tracker stories?
#162601645

Screenshots
<img width="1440" alt="screen shot 2018-12-17 at 5 30 28 am" src="https://user-images.githubusercontent.com/9901086/50069510-78f07180-01db-11e9-8e54-e5c4a027c2be.png">


