### PR TITLE
[ft #161382361] Add tags to a single article

### DIFF
--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -82,3 +82,8 @@ height: 100%;
   font-style: italic;
   color: rgb(6, 56, 39);
 }
+
+.tags{
+  margin-left: 5px;
+  margin-right: 5px;
+}

--- a/src/containers/viewArticles/articleView.jsx
+++ b/src/containers/viewArticles/articleView.jsx
@@ -36,13 +36,30 @@ export const SocialMediaSection = () => (
   </div>
 );
 
+export const TagSection = tags => {
+  const tagValues = tags.tags.map((tag, index) => (
+    <span className="badge badge-pill badge-info tags" key={index}>
+      {tag}
+    </span>
+  ));
+  return (
+    <div>
+      <p>
+        Tags:
+        {tagValues}
+      </p>
+    </div>
+  );
+};
+
 export const ArticleSection = ({
   img,
   description,
   body,
   author,
   publishDate,
-  readTime
+  readTime,
+  tags
 }) => (
   <div className="col-md-6 mb-4">
     {/* <!--Featured Image--> */}
@@ -58,23 +75,17 @@ export const ArticleSection = ({
         <p className="h5 my-4">{description}</p>
         <p>{body}</p>
         <p className="publish__date">
-          Published on:
+            Published on:
           <Moment format="YYYY/MM/DD">{publishDate}</Moment>
         </p>
         <p>
-      By:
+            By:
           {author}
         </p>
       </div>
 
       <hr />
-      <p>
-        Tags:
-        <span className="badge badge-pill badge-info">Science</span>
-        <span className="badge badge-pill badge-info">Adventure</span>
-        <span className="badge badge-pill badge-info">Experiment</span>
-        <span className="badge badge-pill badge-info">Andela</span>
-      </p>
+      <TagSection tags={tags} />
     </div>
   </div>
 );
@@ -84,6 +95,13 @@ export class SingleArticle extends Component {
     const id = localStorage.getItem("articleId");
     this.props.singleArticleAction(id);
   }
+
+  state = {
+    tags:
+      JSON.parse(localStorage.getItem("tags")) == null
+        ? [""]
+        : JSON.parse(localStorage.getItem("tags"))
+  };
 
   render() {
     const article = this.props.Article.article;
@@ -103,6 +121,7 @@ export class SingleArticle extends Component {
                   publishDate={article.created_at}
                   author={author}
                   readTime={article.read_time}
+                  tags={this.state.tags}
                 />
               </div>
             </section>

--- a/src/containers/viewArticles/articlesView.jsx
+++ b/src/containers/viewArticles/articlesView.jsx
@@ -72,9 +72,10 @@ export class ArticleDetails extends Component {
     this.props.articlesActions();
   }
 
-  onClickHandler = (id, articleAuthor) => event => {
+  onClickHandler = (id, articleAuthor,tags) => event => {
     localStorage.setItem("articleId", id);
     localStorage.setItem("articleAuthor", articleAuthor);
+    localStorage.setItem("tags", JSON.stringify(tags));
   };
 
 
@@ -89,7 +90,8 @@ export class ArticleDetails extends Component {
           img={article.image_url}
           onClickHandler={this.onClickHandler(
             article.id,
-            article.author.username
+            article.author.username,
+            article.tag_list
           )}
         />
       ));

--- a/tests/integerationTests/ArticleView.test.jsx
+++ b/tests/integerationTests/ArticleView.test.jsx
@@ -8,6 +8,7 @@ import {
   SocialMediaSection,
   ArticleSection,
   SingleArticle,
+  TagSection,
   mapStateToProps,
   mapDispatchToProps
 } from "../../src/containers/viewArticles/articleView";
@@ -24,17 +25,21 @@ describe("<SocialMediaSection/>", () => {
 
 describe("<ArticleSection/>", () => {
   it("it mounts the articles instance", () => {
-    const wrapper = shallow(<ArticleSection />);
+        const tags = ["code", "web"]
+    const wrapper = mount(<ArticleSection  tags= {tags}/>);
   });
 });
 
 describe("<SingleArticle/>", () => {
   it("mounts the articles component", () => {
+    const tags = ["code", "web"]
     const props = {
       singleArticleAction: () => jest.fn(),
       Article: {
         article: {
-          body: "this a test article", description:"Ever wonder how", id: 20
+          body: "this a test article",
+          description: "Ever wonder how",
+          id: 20
         }
       }
     };
@@ -47,24 +52,30 @@ describe("<SingleArticle/>", () => {
           />
         </Router>
       </Provider>
-    );
+    ).setState({tags:[]});
+    wrapper.setProps(tags)
   });
 });
-
 
 describe("Checks whether mapstate to props returns", () => {
   const expectedProp = {
     singleArticleReducer: {
-      article: [{ id:5,user:"chucky",body:"user already registered" }],
+      article: [{ id: 5, user: "chucky", body: "user already registered" }]
     }
   };
 
   expect(mapStateToProps(expectedProp)).toBeTruthy();
 });
 
-
 describe("Checks whether mapdispatch to props returns", () => {
-  const dispatch = jest.fn()
+  const dispatch = jest.fn();
   mapDispatchToProps(dispatch).singleArticleAction();
   expect(dispatch.mock.calls.length).toBe(1);
+});
+
+describe("<TagSection/>", () => {
+  it("it mounts the tags selection to test", () => {
+    const tags = ["code", "web"];
+    const wrapper = mount(<TagSection tags={tags} />);
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Add tags to a single article.
#### Description of Task to be completed?
Adds tags to an article when one is viewing.
#### How should this be manually tested?
- Clone this branch
- Install the dependencies using `yarn `
- Click on the single article page and tags will be displayed.

#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
#161382361



